### PR TITLE
feat: install everything to the root user so it plays nicely with github runners

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -65,16 +65,10 @@ COPY --chown=root:root --from=echidna /usr/local/bin/echidna /usr/local/bin/echi
 COPY --chown=root:root --from=medusa /usr/local/bin/medusa /usr/local/bin/medusa
 RUN medusa completion bash > /etc/bash_completion.d/medusa
 
-# Add a user with passwordless sudo
-RUN useradd -m ethsec && \
-    usermod -aG sudo ethsec && \
-    echo 'ethsec ALL=(ALL) NOPASSWD: ALL' >> /etc/sudoers
-
-##### user-level setup follows
 ##### Things should be installed in $HOME from now on
-USER ethsec
-WORKDIR /home/ethsec
-ENV HOME="/home/ethsec"
+USER root
+WORKDIR /root
+ENV HOME="/root"
 ENV PATH="${PATH}:${HOME}/.local/bin:${HOME}/.vyper/bin:${HOME}/.foundry/bin"
 
 # Install vyper compiler
@@ -97,7 +91,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/foundry-rs/foundry/ded0317584bd
     done
 
 # Install python tools
-RUN pip3 install --no-cache-dir --user \
+RUN pip3 install --no-cache-dir \
     pyevmasm \
     solc-select \
     crytic-compile \


### PR DESCRIPTION
this is a proof of concept, I really like the idea of runnig CI inside a docker image where the dev toolchain is already installed, with eth-security-toolbox fitting the bill almost perfectly.

however, github runners assume everything will run as the root user, which is not compatible with the aforementioned image using a non-root user, and trying to use it as-is causes runs to fail with various filesystem permission errors

I simply ran:

```
> docker build -t 0xteddybear/eth-security-toolbox-ci .
> docker push 0xteddybear/eth-security-toolbox-ci:latest
```
and used the image as the `container` field of github workflows

this is not ideal, and we should either
- maintain the docker image under wonderland's org
- convince trailofbits to maintain a tag of the same image with these modifications